### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This Model Context Protocol (MCP) server integrates with Contentstack's Content 
 
 > **Note:** This is an early version of Contentstack MCP Server. Features and APIs are subject to change. See the [Roadmap](#roadmap) for upcoming improvements and planned features.
 
+<a href="https://glama.ai/mcp/servers/@darekrossman/contentstack-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@darekrossman/contentstack-mcp/badge" alt="contentstack-mcp MCP server" />
+</a>
+
 ## Table of Contents
 - [Features](#features)
 - [Installation](#installation)
@@ -261,4 +265,3 @@ MIT
 ---
 
 **Disclaimer:** This project is not affiliated with, endorsed by, or supported by Contentstack. It is an independent open-source project designed to work with the Contentstack API.
-


### PR DESCRIPTION
This PR adds a badge for the [contentstack-mcp](https://glama.ai/mcp/servers/@darekrossman/contentstack-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@darekrossman/contentstack-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@darekrossman/contentstack-mcp/badge" alt="contentstack-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.